### PR TITLE
feat: 마이페이지 프로필 이미지 초기화 바텀 시트 및 비즈니스 로직 추가

### DIFF
--- a/24th-App-Team-1-iOS/Domain/AllDomain/Sources/Entities/UpdateUserProfileImageQuery.swift
+++ b/24th-App-Team-1-iOS/Domain/AllDomain/Sources/Entities/UpdateUserProfileImageQuery.swift
@@ -10,9 +10,9 @@ import Foundation
 
 
 public struct UpdateUserProfileImageRequestQuery {
-    public let url: String
+    public let url: String?
     
-    public init(url: String) {
+    public init(url: String?) {
         self.url = url
     }
 }

--- a/24th-App-Team-1-iOS/Feature/AllFeature/Sources/Presentation/Reactors/ProfileSettingViewReactor.swift
+++ b/24th-App-Team-1-iOS/Feature/AllFeature/Sources/Presentation/Reactors/ProfileSettingViewReactor.swift
@@ -38,6 +38,7 @@ public final class ProfileSettingViewReactor: Reactor {
     public enum Action {
         case didUpdateIntroduceProfile(String)
         case didTappedProfileEditButton(Data)
+        case didTappedRemoveProfileImage
         case didTapUpdateUserButton
         case viewWillAppear
     }
@@ -176,6 +177,22 @@ public final class ProfileSettingViewReactor: Reactor {
                 .just(.setSelectedImage(true)),
                 .just(.setButtonEnabled(true))
             )
+        case .didTappedRemoveProfileImage:
+            let query = UpdateUserProfileImageRequestQuery(url: nil)
+            
+            return updateUserProfileImageUseCase.execute(query: query)
+                .asObservable()
+                .flatMap { entity -> Observable<Mutation> in
+                    guard let entity else {
+                        return .empty()
+                    }
+                    
+                    return .concat(
+                        .just(.setLoading(false)),
+                        .just(.setUserProfileImageItem(entity)),
+                        .just(.setLoading(true))
+                    )
+                }
         }
     }
     

--- a/24th-App-Team-1-iOS/Feature/AllFeature/Sources/Presentation/ViewControllers/ProfileSettingViewController.swift
+++ b/24th-App-Team-1-iOS/Feature/AllFeature/Sources/Presentation/ViewControllers/ProfileSettingViewController.swift
@@ -221,9 +221,9 @@ public final class ProfileSettingViewController: BaseViewController<ProfileSetti
         userProfileEditButton
             .rx.tap
             .throttle(.milliseconds(300), scheduler: MainScheduler.instance)
+            .withUnretained(self)
             .bind(with: self) { owner, _ in
-                owner.pickerViewController.modalPresentationStyle = .fullScreen
-                owner.present(owner.pickerViewController, animated: true)
+                owner.showProfileActionSheetViewController()
             }
             .disposed(by: disposeBag)
         
@@ -407,4 +407,34 @@ public final class ProfileSettingViewController: BaseViewController<ProfileSetti
             .disposed(by: disposeBag)
         
     }
+}
+
+
+extension ProfileSettingViewController {
+    
+    private func showProfileActionSheetViewController() {
+        let profileEditAlertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+        
+        let addProfileImageAction = UIAlertAction(title: "앨범에서 사진 선택", style: .default) { _ in
+            self.showPickerViewController()
+        }
+        
+        let removeProfileAction = UIAlertAction(title: "기본 이미지 적용", style: .destructive) { _ in
+            self.reactor?.action.onNext(.didTappedRemoveProfileImage)
+        }
+        
+        let cancelAction = UIAlertAction(title: "취소", style: .cancel)
+        
+        profileEditAlertController.addAction(addProfileImageAction)
+        profileEditAlertController.addAction(removeProfileAction)
+        profileEditAlertController.addAction(cancelAction)
+        
+        self.present(profileEditAlertController, animated: true)
+    }
+    
+    private func showPickerViewController() {
+        pickerViewController.modalPresentationStyle = .fullScreen
+        present(pickerViewController, animated: true)
+    }
+    
 }

--- a/24th-App-Team-1-iOS/Feature/AllFeature/Sources/Presentation/ViewControllers/ProfileSettingViewController.swift
+++ b/24th-App-Team-1-iOS/Feature/AllFeature/Sources/Presentation/ViewControllers/ProfileSettingViewController.swift
@@ -221,7 +221,6 @@ public final class ProfileSettingViewController: BaseViewController<ProfileSetti
         userProfileEditButton
             .rx.tap
             .throttle(.milliseconds(300), scheduler: MainScheduler.instance)
-            .withUnretained(self)
             .bind(with: self) { owner, _ in
                 owner.showProfileActionSheetViewController()
             }

--- a/24th-App-Team-1-iOS/Service/AllService/Sources/DataMapping/UpdateUserProfileImageRequestDTO.swift
+++ b/24th-App-Team-1-iOS/Service/AllService/Sources/DataMapping/UpdateUserProfileImageRequestDTO.swift
@@ -9,9 +9,9 @@ import Foundation
 
 
 public struct UpdateUserProfileImageRequestDTO: Encodable {
-    public let url: String
+    public let url: String?
     
-    public init(url: String) {
+    public init(url: String?) {
         self.url = url
     }
 }


### PR DESCRIPTION

## 개요
- 프로필 설정 화면에 프로필 이미지 설정 바텀 시트 추가
- 이미지 초기화 API 호출 로직 추가

## 작업 내용
- 기존 `UpdateUserProfileImageRequestQuery`, `UpdateUserProfileImageRequestDTO`내부 `url`을 옵셔널 타입으로 변경
- `didTappedRemoveProfileImage` 액션 추가 및 프로필 초기화 API 호출 로직 추가
- `ProfileSettingViewController` 내부 바텀 시트 UI 구현


## 화면 
| 프로필 설정 화면 | 
|--------|
| <img src="https://github.com/user-attachments/assets/21ac2327-b68c-4605-ab0e-89c7ec56e9f0" width="200"/> | 



close: #10 
