### PR TITLE
fix: 투표 화면에서 투표 선택지 클릭 시 강제 종류 되는 이슈 수정해요

### DIFF
--- a/24th-App-Team-1-iOS/Feature/VoteFeature/Sources/Presentation/Reactors/VoteProcessViewReactor.swift
+++ b/24th-App-Team-1-iOS/Feature/VoteFeature/Sources/Presentation/Reactors/VoteProcessViewReactor.swift
@@ -26,6 +26,7 @@ public final class VoteProcessViewReactor: Reactor {
         @Pulse var finalVoteCount: Int
         @Pulse var reportEntity: CreateReportUserEntity?
         @Pulse var isLoading: Bool
+        @Pulse var isEnabled: Bool
         var voteItemEntity: VoteItemEntity?
         var createVoteEntity: CreateVoteEntity?
     }
@@ -46,6 +47,7 @@ public final class VoteProcessViewReactor: Reactor {
         case setProcessCount(Int)
         case setVoteUserItems(VoteUserEntity)
         case setVoteResponseItems(VoteResponseEntity?)
+        case setResultButtonEnabled(Bool)
         case setCreateVoteItems(CreateVoteEntity)
         case setReportItem(CreateReportUserEntity)
     }
@@ -62,7 +64,8 @@ public final class VoteProcessViewReactor: Reactor {
             voteResponseEntity: voteResponseEntity,
             processCount: 1,
             finalVoteCount: 1,
-            isLoading: false
+            isLoading: false,
+            isEnabled: false
         )
         self.createVoteUseCase = createVoteUseCase
         self.createUserReportUseCase = createUserReportUseCase
@@ -72,7 +75,6 @@ public final class VoteProcessViewReactor: Reactor {
         switch action {
         case .viewDidLoad:
             let index = UserDefaultsManager.shared.voteRequest.count
-            
             var voteSectionItems: [VoteProcessItem] = []
             let processCount = UserDefaultsManager.shared.voteRequest.count + 1
             let finalCount = currentState.voteResponseEntity?.response.count ?? 0
@@ -109,20 +111,20 @@ public final class VoteProcessViewReactor: Reactor {
         case let .didTappedQuestionItem(row):
 
             let index = UserDefaultsManager.shared.voteRequest.count
-            guard let request = currentState.voteResponseEntity?.response[index] else { return .empty() }
-            var currentOptions = UserDefaultsManager.shared.voteRequest
+            guard let request = currentState.voteResponseEntity?.response[index] else {
+                return .empty()
+            }
             
             let voteOption = CreateVoteItemReqeuest(
                 userId: request.userInfo.id,
                 voteOptionId: request.voteInfo[row].id
             )
             
-            if index < currentOptions.count {
-                UserDefaultsManager.shared.voteRequest[index] = voteOption
-            } else {
+            if index < request.voteInfo.count - 1 {
                 UserDefaultsManager.shared.voteRequest.append(voteOption)
             }
-            return .empty()
+            let isEnabled = UserDefaultsManager.shared.voteRequest.count == request.voteInfo.count - 1 ? true : false
+            return .just(.setResultButtonEnabled(isEnabled))
             
         case .didTappedResultButton:
             
@@ -183,6 +185,8 @@ public final class VoteProcessViewReactor: Reactor {
             newState.processCount = processCount
         case let .setVoteCount(finalVoteCount):
             newState.finalVoteCount = finalVoteCount
+        case let .setResultButtonEnabled(isEnabled):
+            newState.isEnabled = isEnabled
         }
         return newState
     }

--- a/24th-App-Team-1-iOS/Feature/VoteFeature/Sources/Presentation/ViewControllers/VoteProcessViewController.swift
+++ b/24th-App-Team-1-iOS/Feature/VoteFeature/Sources/Presentation/ViewControllers/VoteProcessViewController.swift
@@ -131,6 +131,7 @@ public final class VoteProcessViewController: BaseViewController<VoteProcessView
             $0.setupButton(text: VoteProcessStr.voteResultText)
             $0.setupFont(font: .Body03)
             $0.isHidden = true
+            $0.isEnabled = false
         }
         
         self.navigationController?.do {
@@ -173,7 +174,7 @@ public final class VoteProcessViewController: BaseViewController<VoteProcessView
         
         resultButton.rx
             .tap
-            .throttle(.milliseconds(300), latest: false, scheduler: MainScheduler.instance)
+            .throttle(.seconds(1), latest: false, scheduler: MainScheduler.instance)
             .map { Reactor.Action.didTappedResultButton }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
@@ -215,6 +216,12 @@ public final class VoteProcessViewController: BaseViewController<VoteProcessView
         
         reactor.pulse(\.$isLoading)
             .bind(to: loadingIndicator.rx.isHidden)
+            .disposed(by: disposeBag)
+        
+        reactor.pulse(\.$isEnabled)
+            .distinctUntilChanged()
+            .observe(on: MainScheduler.instance)
+            .bind(to: resultButton.rx.isEnabled)
             .disposed(by: disposeBag)
         
         reactor.pulse(\.$questionSection)


### PR DESCRIPTION
- VoteProcessViewReactor isEnabled State, setResultButtonEnabled, setResultButtonEnabled Mutation 추가

## 작업 내용

- [ ] `VoteProcessViewController` 투표 API 호출 시 중복 클릭 방지를 위해 `throttle` 시간 1초로 변경
- [ ] `VoteProcessViewReactor` 선택지 추가 시 Index Out Bounds 이슈로 강제 종료 이슈 수정
- [ ] `VoteProcessViewController` 마지막 선택 지 클릭 시 `ResultButton` Enabled True로 반환 하도록 로직 추가

<br/><br/><br/>
## 로직 수정 부분 (Optional)
- 선택 지 클릭시 서버에서 내려주는 투표 갯수와 비교해서 추가를 해야 했었는데 로컬 DB에 있는 데이터 갯수와 비교하다 보니 계속 저장하게 되면서 index Out bounds 이슈가 발생하게 되었습니다.
- 떄문에 서버에서 내려주는 투표 갯수와 비교하여 저장하도록 로직을 수정하였습니다.
- 기존에는 마지막 투표지를 선택하지 않아도 ResultButton을 클릭 할 수 있게 되어있어서 서버에서 내려주는 갯수와 일치 할 경우에만 ResultButton을 활성화 하도록 로직을 수정하였습니다.


<br/><br/><br/>
close: #13 
