### PR TITLE
fix: Tuist 공통 Domain 모듈에 Storage 의존성을 추가해요

### DIFF
--- a/24th-App-Team-1-iOS/Core/Storage/Project.swift
+++ b/24th-App-Team-1-iOS/Core/Storage/Project.swift
@@ -15,7 +15,8 @@ let project = Project
             .core(module: .Storage, dependencies: [
                 .shared(module: .ThirdPartyLib),
                 .domain(module: .LoginDomain),
-                .domain(module: .VoteDomain)
+                .domain(module: .VoteDomain),
+                .core(module: .Extensions)
             ])
         ]
     )

--- a/24th-App-Team-1-iOS/Core/Storage/Sources/UserDefaults/UserDefaultsManager.swift
+++ b/24th-App-Team-1-iOS/Core/Storage/Sources/UserDefaults/UserDefaultsManager.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import LoginDomain
-import Extensions
 import VoteDomain
 
 public class UserDefaultsManager {

--- a/24th-App-Team-1-iOS/Core/Util/Project.swift
+++ b/24th-App-Team-1-iOS/Core/Util/Project.swift
@@ -14,7 +14,8 @@ let project = Project.makeProject(
     targets: [
         .core(module: .Util, dependencies: [
             .shared(module: .ThirdPartyLib),
-            .shared(module: .DesignSystem)
+            .shared(module: .DesignSystem),
+            .domain(module: .CommonDomain)
         ])
     ]
 )

--- a/24th-App-Team-1-iOS/Domain/CommonDomain/Project.swift
+++ b/24th-App-Team-1-iOS/Domain/CommonDomain/Project.swift
@@ -12,7 +12,8 @@ let commonDomain = Project.makeProject(
     module: .domain(.CommonDomain),
     targets: [
         .domain(module: .CommonDomain, dependencies: [
-            .shared(module: .ThirdPartyLib)
+            .shared(module: .ThirdPartyLib),
+            .core(module: .Storage)
         ], product: .staticFramework)
     ]
 )


### PR DESCRIPTION
## 작업 내용

- [x] Storage 모듈에 Extensions 의존성을 추가하여 직접 CommonDomain 모듈에서 Extensions 의존성을 `import` 하지 않도록 수정하였습니다.
- [x]  Util 모듈에 CommonDomain 의존성 추가 하였습니다. 추가한 이유는 `WSGlobalServiceProtocol`에 CommonDomain 내부에 있는 파일을 불러와야 하는데 의존성이 없다 보니 `Clean` - `Build` 하면 실패하는 경우가 발생 하였습니다.

## 변경 사항
- `Storage` 모듈에 `Extensions` 의존성 추가
- `Util` 모듈에 `Common Domain` 의존성 추가


<br/>
close: #18 
