### PR TITLE
fix: 투표 메인화면 오타 및 레이아웃 간격 수정해요

### DIFF
--- a/24th-App-Team-1-iOS/Feature/AllFeature/Sources/Presentation/Reactors/ProfileSettingViewReactor.swift
+++ b/24th-App-Team-1-iOS/Feature/AllFeature/Sources/Presentation/Reactors/ProfileSettingViewReactor.swift
@@ -189,6 +189,7 @@ public final class ProfileSettingViewReactor: Reactor {
                     
                     return .concat(
                         .just(.setLoading(false)),
+                        .just(.setUpdateUserProfile(true)),
                         .just(.setUserProfileImageItem(entity)),
                         .just(.setLoading(true))
                     )

--- a/24th-App-Team-1-iOS/Feature/AllFeature/Sources/Presentation/ViewControllers/ProfileSettingViewController.swift
+++ b/24th-App-Team-1-iOS/Feature/AllFeature/Sources/Presentation/ViewControllers/ProfileSettingViewController.swift
@@ -30,7 +30,7 @@ public final class ProfileSettingViewController: BaseViewController<ProfileSetti
     private let userNameTextField: WSTextField = WSTextField(state: .withRightItem(DesignSystemAsset.Images.lock.image), placeholder: "김선희", title: "이름")
     private let userGenderTextFiled: WSTextField = WSTextField(state: .withRightItem(DesignSystemAsset.Images.lock.image), placeholder: "여", title: "성별")
     private let userClassInfoTextField: WSTextField = WSTextField(state: .withRightItem(DesignSystemAsset.Images.lock.image), placeholder: "역삼중학교 1학년 6반", title: "학적 정보")
-    private let userIntroduceTextField: WSTextField = WSTextField(state: .default, placeholder: "안녕 난 선희다", title: "MBTI")
+    private let userIntroduceTextField: WSTextField = WSTextField(state: .default, placeholder: "|(ex. 귀염둥이 엥뿌삐 ENFP)", title: "MBTI")
     private let privacyButton: WSButton = WSButton(wsButtonType: .default(12))
     private let editButton: WSButton = WSButton(wsButtonType: .default(12))
     private let errorLabel: WSLabel = WSLabel(wsFont: .Body07)
@@ -344,7 +344,7 @@ public final class ProfileSettingViewController: BaseViewController<ProfileSetti
             .disposed(by: disposeBag)
             
         reactor.state
-            .map { $0.userProfileEntity?.profile.iconUrl }
+            .map { $0.userProfileImageEntity?.url }
             .filter { $0 == nil }
             .map { _ in DesignSystemAsset.Images.profile.image }
             .distinctUntilChanged()
@@ -390,6 +390,7 @@ public final class ProfileSettingViewController: BaseViewController<ProfileSetti
         reactor.pulse(\.$isUpdate)
             .filter{ $0 == true }
             .bind(with: self) { owner, _ in
+                owner.view.endEditing(true)
                 owner.showWSToast(image: .check, message: "수정 완료")
             }
             .disposed(by: disposeBag)

--- a/24th-App-Team-1-iOS/Feature/VoteFeature/Sources/Presentation/Cell/VoteResultCollectionViewCell.swift
+++ b/24th-App-Team-1-iOS/Feature/VoteFeature/Sources/Presentation/Cell/VoteResultCollectionViewCell.swift
@@ -215,7 +215,7 @@ extension VoteResultCollectionViewCell: ReactorKit.View {
         
         reactor.state
             .filter { $0.winnerUser == nil }
-            .map { _ in "친구에게 데려오기" }
+            .map { _ in "친구 데려오기" }
             .distinctUntilChanged()
             .bind(to: resultDescriptionLabel.rx.text)
             .disposed(by: disposeBag)

--- a/24th-App-Team-1-iOS/Feature/VoteFeature/Sources/Presentation/Cell/VoteSentTableViewCell.swift
+++ b/24th-App-Team-1-iOS/Feature/VoteFeature/Sources/Presentation/Cell/VoteSentTableViewCell.swift
@@ -82,6 +82,9 @@ final class VoteSentTableViewCell: UITableViewCell {
         }
         sentImageView.do {
             $0.image = DesignSystemAsset.Images.imgInventoryProfileFiled.image
+            $0.layer.cornerRadius = 20
+            $0.contentMode = .scaleAspectFill
+            $0.clipsToBounds = true
         }
         
         sentTitleLabel.do {

--- a/24th-App-Team-1-iOS/Feature/VoteFeature/Sources/Presentation/Constants/Constants.swift
+++ b/24th-App-Team-1-iOS/Feature/VoteFeature/Sources/Presentation/Constants/Constants.swift
@@ -33,14 +33,14 @@ enum Const {
     static let voteResultTopSpacing: CGFloat = Device.isTouchIDCapableDevice ? 0 : 32
     static let voteResultItemHeight: CGFloat = Device.isTouchIDCapableDevice ? 330 : 392
     
-    static let voteResultRankViewWidth: CGFloat = Device.isTouchIDCapableDevice ? 86 : 98
-    static let voteResultRankViewHeight: CGFloat = Device.isTouchIDCapableDevice ? 31 : 36
+    static let voteResultRankViewWidth: CGFloat = Device.isTouchIDCapableDevice ? 86 : 102
+    static let voteResultRankViewHeight: CGFloat = Device.isTouchIDCapableDevice ? 31 : 38
     static let voteResultRankViewTopSpacing: CGFloat = Device.isTouchIDCapableDevice ? 16 : 18
     static let voteResultRankViewLeftSpacing: CGFloat = Device.isTouchIDCapableDevice ? 20 : 20
     static let voteResultRankViewFont: WSFont = Device.isTouchIDCapableDevice ? .Header02 : .Header01
     static let voteRankImageViewSize: CGFloat = Device.isTouchIDCapableDevice ? 26 : 30
     static let voteRankImageViewLeftSpacing: CGFloat = Device.isTouchIDCapableDevice ? 10 : 12
-    static let voteRankLabelLeftSpacing: CGFloat = Device.isTouchIDCapableDevice ? 10 : 12
+    static let voteRankLabelLeftSpacing: CGFloat = Device.isTouchIDCapableDevice ? 10 : 8
     static let voteRankLabelHeight: CGFloat = Device.isTouchIDCapableDevice ? 21 : 30
     
     static let voteResultDescriptionLabelTopSpacing: CGFloat = Device.isTouchIDCapableDevice ? 8 : 12

--- a/24th-App-Team-1-iOS/Feature/VoteFeature/Sources/Presentation/ViewControllers/VoteInventoryDetailViewController.swift
+++ b/24th-App-Team-1-iOS/Feature/VoteFeature/Sources/Presentation/ViewControllers/VoteInventoryDetailViewController.swift
@@ -152,6 +152,9 @@ public final class VoteInventoryDetailViewController: BaseViewController<VoteInv
         
         detailFaceView.do {
             $0.image = DesignSystemAsset.Images.imgResultCharacter.image
+            $0.contentMode = .scaleAspectFill
+            $0.layer.cornerRadius = 60
+            $0.clipsToBounds = true
         }
         
         detailDescrptionLabel.do {

--- a/24th-App-Team-1-iOS/Tuist/ProjectDescriptionHelpers/InfoPlist+Templates.swift
+++ b/24th-App-Team-1-iOS/Tuist/ProjectDescriptionHelpers/InfoPlist+Templates.swift
@@ -21,7 +21,7 @@ extension InfoPlist {
         var basePlist: [String: Plist.Value] = [
             "CFBundleDisplayName": .string("WeSpot"),
             "UIUserInterfaceStyle": .string("Dark"),
-            "CFBundleShortVersionString": .string("1.3.0"),
+            "CFBundleShortVersionString": .string("1.3.1"),
             "CFBundleVersion": .string("1"),
             "UILaunchStoryboardName": .string("LaunchScreen"),
             "UISupportedInterfaceOrientations": .array([.string("UIInterfaceOrientationPortrait")]),


### PR DESCRIPTION
## 투표 및 프로필 화면 오타 수정
- 투표 화면 및 프로필 화면 오타를 수정하였습니다.

## 프로필 설정화면 기본 이미지 설정 시 Toast View 띄우는 State 값 추가했습니다.
- 프로필 기본 이미지 설정 시 Toast View를 띄우도록 하여 이미지가 정상적으로 설정됐는지를 확인하도록 로직을 수정했습니다.

## 투표 결과 화면 Spacing 값 수정
- 투표 결과 화면에 Spacing 값이 Figma와 일치하지 않아 `Constant` 값을 수정하였습니다.

## 투표 목록 상세화면 cornerRadius Property 추가
- 투표 목록 상세화면 ProfileImageView에 cornerRadius Property 값을 추가하였습니다.
- ProfileImageView에 conentMode를 `scaleAspectFill` 속성으로 추가하였습니다.

<br/><br/><br/>
close: #21 
