### PR TITLE
fix: 투표 진행화면 Memory Cache 로직 추가해요

### DIFF
--- a/24th-App-Team-1-iOS/Core/Storage/Sources/Cache/WSCacheManager.swift
+++ b/24th-App-Team-1-iOS/Core/Storage/Sources/Cache/WSCacheManager.swift
@@ -1,0 +1,38 @@
+//
+//  WSCacheManager.swift
+//  Storage
+//
+//  Created by 김도현 on 1/16/25.
+//
+
+import Foundation
+
+public enum WSCacheKey: String {
+    case voteOptions = "vote_options"
+}
+
+
+public final class WSCacheManager {
+    private let cache = NSCache<NSString, AnyObject>()
+    
+    public static let shared = WSCacheManager()
+    
+    /// 캐시 데이터를  저장 하기 위한 메서드
+    public func save<T: Decodable>(response: T, for key: String) {
+        let wrapper = WSCacheWrapper(value: response)
+        cache.setObject(wrapper, forKey: key as NSString)
+    }
+    
+    /// 캐시 데이터를 가져오기 위한 메서드
+    public func getResponse<T: Decodable>(for key: String) -> T? {
+        guard let wrapper = cache.object(forKey: key as NSString) as? WSCacheWrapper<T> else {
+            return nil
+        }
+        return wrapper.value
+    }
+    
+    /// 캐시 데이터를 삭제하기 위한 메서드
+    public func claer(for key: String) {
+        cache.removeObject(forKey: key as NSString)
+    }
+}

--- a/24th-App-Team-1-iOS/Core/Storage/Sources/Cache/WSCacheWrapper.swift
+++ b/24th-App-Team-1-iOS/Core/Storage/Sources/Cache/WSCacheWrapper.swift
@@ -1,0 +1,16 @@
+//
+//  WSCacheWrapper.swift
+//  Storage
+//
+//  Created by 김도현 on 1/20/25.
+//
+
+import Foundation
+
+final class WSCacheWrapper<T: Decodable>: NSObject {
+    let value: T
+    
+    init(value: T) {
+        self.value = value
+    }
+}

--- a/24th-App-Team-1-iOS/Service/VoteService/Sources/Repository/VoteRepository.swift
+++ b/24th-App-Team-1-iOS/Service/VoteService/Sources/Repository/VoteRepository.swift
@@ -10,6 +10,7 @@ import Foundation
 import Networking
 import Util
 import VoteDomain
+import Storage
 
 import RxSwift
 import RxCocoa
@@ -43,6 +44,7 @@ public final class VoteRepository: VoteRepositoryProtocol {
         return networkService.request(endPoint: endPoint)
             .asObservable()
             .logErrorIfDetected(category: Network.error)
+            .do { _ in WSCacheManager.shared.claer(for: WSCacheKey.voteOptions.rawValue) }
             .decodeMap(CreateVoteResponseDTO.self)
             .map { $0.toDomain() }
             .asSingle()


### PR DESCRIPTION
## 작업 내용
- `Storage` 모듈 내부 `NSCache`를 사용하여 `WSCacheManager` 구현
-  `VoteResponseDTO` 호출 시 기존 ResponseDTO을 Cache에 저장해요

## 화면
<img src="https://github.com/user-attachments/assets/cbdefdc6-ae06-4412-9424-8a1b181e4041" width="200"/>


<br/>
close: #26 
