### PR TITLE
feat: SwiftUI 기반 네트워크 모듈 및 프로필 온보딩 UI 추가

### DIFF
--- a/24th-App-Team-1-iOS/App/Sources/Applications/SceneDelegate.swift
+++ b/24th-App-Team-1-iOS/App/Sources/Applications/SceneDelegate.swift
@@ -26,6 +26,7 @@ import KakaoSDKAuth
 import MessageFeature
 import KeychainSwift
 
+
 public class SceneDelegate: UIResponder, UISceneDelegate {
     
     var window: UIWindow?
@@ -98,6 +99,24 @@ extension SceneDelegate {
     //TODO: Coordinator 패턴으로 수정
     private func setupViewControllers() {
         
+        
+        NotificationCenter.default.addObserver(forName: .dismissProfileOnboardingView, object: nil, queue: .main) { [weak self]  _ in
+            guard let self else { return }
+            setupMainViewController()
+            
+            let rootViewController = self.window?.rootViewController?.topMostViewController()
+            
+            let profileOnboardingViewController = ProfileOnboardingHostingViewController(rootView: ProfileOnboardingView(viewModel: ProfileOnboardingViewModel()))
+            rootViewController?.navigationController?.pushViewController(profileOnboardingViewController, animated: false)
+            
+        }
+        
+        NotificationCenter.default.addObserver(forName: .showProfileOnboardingView, object: nil, queue: .main) { _ in
+            guard let topViewController = self.window?.rootViewController else { return }
+            let profileOnboardingViewController = ProfileOnboardingHostingViewController(rootView: ProfileOnboardingView(viewModel: ProfileOnboardingViewModel()))
+            topViewController.navigationController?.pushViewController(profileOnboardingViewController, animated: true)
+        }
+        
         NotificationCenter.default.addObserver(forName: .showVoteMainViewController, object: nil, queue: .main) { [weak self] _ in
             guard let self else { return }
             setupMainViewController()
@@ -107,8 +126,12 @@ extension SceneDelegate {
             guard let self else { return }
             let topViewController = self.window?.rootViewController?.topMostViewController()
             let profileSettingViewController = DependencyContainer.shared.injector.resolve(ProfileSettingViewController.self)
-            topViewController?.navigationController?.pushViewController(profileSettingViewController, animated: true)
+            if let navigationController = topViewController?.navigationController {
+                navigationController.popViewController(animated: false)
+                navigationController.pushViewController(profileSettingViewController, animated: true)
+            }
         }
+
         
         NotificationCenter.default.addObserver(forName: .showSignInViewController, object: nil, queue: .main) { [weak self] _ in
             guard let self else { return }

--- a/24th-App-Team-1-iOS/App/Sources/DIContainer/DoaminDI/DomainAssembly.swift
+++ b/24th-App-Team-1-iOS/App/Sources/DIContainer/DoaminDI/DomainAssembly.swift
@@ -40,6 +40,11 @@ struct DomainAssembly: Assembly {
             return CreateReportUserUseCase(commonRepositroy: repository)
         }
         
+        container.register(FetchProfileOnboardingInfoUseCaseProtocol.self) { resolver in
+            let repository = resolver.resolve(CommonRepositoryProtocol.self)!
+            return FetchProfileOnboardingInfoUseCase(commonRepository: repository)
+        }
+        
         container.register(CreatePresigendURLUseCaseProtocol.self) { resolver in
             let repository = resolver.resolve(CommonRepositoryProtocol.self)!
             return CreatePresigendURLUseCase(commonRepository: repository)

--- a/24th-App-Team-1-iOS/App/Sources/DIContainer/PresentationDI/Login/SplashPresentationAssembly.swift
+++ b/24th-App-Team-1-iOS/App/Sources/DIContainer/PresentationDI/Login/SplashPresentationAssembly.swift
@@ -26,6 +26,15 @@ struct SplashPresentationAssembly: Assembly {
             let reactor = resolver.resolve(SplashViewReactor.self, argument: accessToken)!
             return SplashViewController(reactor: reactor)
         }
+        
+        container.register(ProfileOnboardingView.self) { resolver in
+            let viewModel = resolver.resolve(ProfileOnboardingViewModel.self)!
+            return ProfileOnboardingView(viewModel: viewModel)
+        }
+        
+        container.register(ProfileOnboardingViewModel.self) { _ in
+            return ProfileOnboardingViewModel()
+        }
     }
     
 }

--- a/24th-App-Team-1-iOS/Core/Extensions/Sources/NotificationName+Extensions.swift
+++ b/24th-App-Team-1-iOS/Core/Extensions/Sources/NotificationName+Extensions.swift
@@ -20,4 +20,6 @@ public extension Notification.Name {
     static let showVoteEffectViewController = Notification.Name("showVoteEffectViewController")
     static let showVoteInventoryViewController = Notification.Name("showVoteInventoryViewController")
     static let showProfileSettingViewController = Notification.Name("showProfileSettingViewController")
+    static let showProfileOnboardingView = Notification.Name("showForceProfileOnboardingView")
+    static let dismissProfileOnboardingView = Notification.Name("dismissProfileOnboardingView")
 }

--- a/24th-App-Team-1-iOS/Core/Networking/Sources/Implement/implementation/EndPointImpl/CommonEndPoint.swift
+++ b/24th-App-Team-1-iOS/Core/Networking/Sources/Implement/implementation/EndPointImpl/CommonEndPoint.swift
@@ -33,6 +33,8 @@ public enum CommonEndPoint: WSNetworkEndPoint {
     
     case uploadProfileImage(String)
     
+    case fetchProfileOnboarding(Encodable)
+    
     public var spec: WSNetworkSpec {
         switch self {
         case .fetchUserProfile:
@@ -49,6 +51,8 @@ public enum CommonEndPoint: WSNetworkEndPoint {
             return WSNetworkSpec(method: .get, url: "\(WSNetworkConfigure.baseURL)/image/presigned-url")
         case let .uploadProfileImage(presignedURL):
             return WSNetworkSpec(method: .put, url: presignedURL)
+        case let .fetchProfileOnboarding(pushType):
+            return WSNetworkSpec(method: .get, url: "\(WSNetworkConfigure.baseURL)/update-modal")
         }
     }
     
@@ -68,6 +72,8 @@ public enum CommonEndPoint: WSNetworkEndPoint {
             return "/image/presigned-url"
         case .uploadProfileImage:
             return ""
+        case .fetchProfileOnboarding:
+            return "/update-modal"
         }
     }
     
@@ -87,6 +93,8 @@ public enum CommonEndPoint: WSNetworkEndPoint {
             return .get
         case .uploadProfileImage:
             return .put
+        case .fetchProfileOnboarding:
+            return .get
         }
     }
     
@@ -98,7 +106,8 @@ public enum CommonEndPoint: WSNetworkEndPoint {
             return .requestBody(body)
         case let .updateUserProfile(body):
             return .requestBody(body)
-        case let .fetchProfilePresignedURL(query):
+        case let .fetchProfilePresignedURL(query),
+             let .fetchProfileOnboarding(query):
             return .requestQuery(query)
         default:
             return .none

--- a/24th-App-Team-1-iOS/Core/Networking/Sources/Implement/implementation/ServiceImpl/WSNetworkAsyncService.swift
+++ b/24th-App-Team-1-iOS/Core/Networking/Sources/Implement/implementation/ServiceImpl/WSNetworkAsyncService.swift
@@ -1,0 +1,44 @@
+//
+//  WSNetworkAsyncService.swift
+//  Networking
+//
+//  Created by 김도현 on 2/25/25.
+//
+
+import Foundation
+
+import Alamofire
+
+public final class WSNetworkAsyncService: WSNetworkAsyncServiceProtocol {
+    
+    private static let session: Session = {
+        let networkMonitor: WSNetworkMonitor = WSNetworkMonitor()
+        let networkConfigure: URLSessionConfiguration = URLSessionConfiguration.af.default
+        let interceptor = WSNetworkInterceptor()
+        networkConfigure.timeoutIntervalForRequest = 60
+        let networkSession: Session = Session(
+            configuration: networkConfigure,
+            interceptor: interceptor,
+            eventMonitors: [networkMonitor]
+        )
+        return networkSession
+    }()
+    
+    public init() { }
+    
+    public func request<T: Decodable>(endPoint: any URLRequestConvertible) async throws -> T {
+        
+        return try await withCheckedThrowingContinuation { continuation in
+            WSNetworkAsyncService.session.request(endPoint)
+                .responseDecodable(of: T.self) { response in
+                    switch response.result {
+                    case let .success(response):
+                        continuation.resume(returning: response)
+                    case let .failure(error):
+                        continuation.resume(throwing: error)
+                    }
+                }
+        }
+    }
+
+}

--- a/24th-App-Team-1-iOS/Core/Networking/Sources/Implement/implementation/ServiceImpl/WSNetworkService.swift
+++ b/24th-App-Team-1-iOS/Core/Networking/Sources/Implement/implementation/ServiceImpl/WSNetworkService.swift
@@ -32,6 +32,7 @@ public final class WSNetworkService: WSNetworkServiceProtocol {
     public func request(endPoint: URLRequestConvertible) -> Single<Data> {
         return Single<Data>.create { single in
             WSNetworkService.session.request(endPoint)
+                .validate(statusCode: 200..<300)
                 .responseData { response in
                     switch response.result {
                     case let .success(response):
@@ -57,6 +58,7 @@ public final class WSNetworkService: WSNetworkServiceProtocol {
     public func requestWithStatusCode(endPoint: URLRequestConvertible) -> Single<(data: Data, statusCode: Int)> {
         return Single<(data: Data, statusCode: Int)>.create { single in
             WSNetworkService.session.request(endPoint)
+                .validate(statusCode: 200..<300)
                 .responseData { response in
                     let statusCode = response.response?.statusCode ?? 0
                     switch response.result {

--- a/24th-App-Team-1-iOS/Core/Networking/Sources/Protocol/ServiceProtocol/WSNetworkAsyncServiceProtocol.swift
+++ b/24th-App-Team-1-iOS/Core/Networking/Sources/Protocol/ServiceProtocol/WSNetworkAsyncServiceProtocol.swift
@@ -1,0 +1,14 @@
+//
+//  WSNetworkAsyncServiceProtocol.swift
+//  Networking
+//
+//  Created by 김도현 on 2/25/25.
+//
+
+import Foundation
+
+import Alamofire
+
+public protocol WSNetworkAsyncServiceProtocol {
+    func request<T: Decodable>(endPoint: URLRequestConvertible) async throws -> T
+}

--- a/24th-App-Team-1-iOS/Core/Networking/Sources/TokenManager/TokenStorage/ReissueToken.swift
+++ b/24th-App-Team-1-iOS/Core/Networking/Sources/TokenManager/TokenStorage/ReissueToken.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct ReissueToken: Encodable {
-    let token: String
+    let refreshToken: String
 }
 
 struct AccessToken: Decodable {

--- a/24th-App-Team-1-iOS/Core/Util/Sources/Helpers/WSNotificationHandler.swift
+++ b/24th-App-Team-1-iOS/Core/Util/Sources/Helpers/WSNotificationHandler.swift
@@ -28,7 +28,7 @@ public final class WSNotificationHandler: NSObject, UNUserNotificationCenterDele
         case .voteRecevied:
             NotificationCenter.default.post(name: .showVoteInventoryViewController, object: nil)
         case .profile:
-            NotificationCenter.default.post(name: .showProfileSettingViewController, object: nil)
+            NotificationCenter.default.post(name: .showProfileOnboardingView, object: nil)
         default:
             break
         }

--- a/24th-App-Team-1-iOS/Domain/CommonDomain/Sources/Entities/ProfileOnboardingEntity.swift
+++ b/24th-App-Team-1-iOS/Domain/CommonDomain/Sources/Entities/ProfileOnboardingEntity.swift
@@ -1,0 +1,80 @@
+//
+//  ProfileOnboardingEntity.swift
+//  CommonDomain
+//
+//  Created by 김도현 on 2/25/25.
+//
+
+import Foundation
+
+
+public struct ProfileOnboardingEntity: Identifiable {
+    public let id: Int
+    public let name: String
+    public let components: [ProfileOnboardingComponentsEntity]
+    
+    public init(id: Int, name: String, components: [ProfileOnboardingComponentsEntity]) {
+        self.id = id
+        self.name = name
+        self.components = components
+    }
+}
+
+
+public struct ProfileOnboardingComponentsEntity {
+    public let componentType: String
+    public let titleText: String?
+    public let imageURL: String?
+    public let width: Int?
+    public let height: Int?
+    public let buttonComponentList: [ProfileButtonComponentListEntity]?
+    
+    public init(
+        componentType: String,
+        titleText: String?,
+        imageURL: String?,
+        width: Int?,
+        height: Int?,
+        buttonComponentList: [ProfileButtonComponentListEntity]?
+    ) {
+        self.componentType = componentType
+        self.titleText = titleText
+        self.imageURL = imageURL
+        self.width = width
+        self.height = height
+        self.buttonComponentList = buttonComponentList
+    }
+}
+
+public struct ProfileButtonComponentListEntity {
+    public let text: String
+    public let textColor: String
+    public let pressColor: String
+    public let buttonColor: String
+    public let onClickAction: ProfileButtonClickActionEntity
+    
+    public init(
+        text: String,
+        textColor: String,
+        pressColor: String,
+        buttonColor: String,
+        onClickAction: ProfileButtonClickActionEntity
+    ) {
+        self.text = text
+        self.textColor = textColor
+        self.pressColor = pressColor
+        self.buttonColor = buttonColor
+        self.onClickAction = onClickAction
+    }
+}
+
+
+public struct ProfileButtonClickActionEntity {
+    public let type: String?
+    public let deepLink: String?
+    
+    public init(type: String?, deepLink: String?) {
+        self.type = type
+        self.deepLink = deepLink
+    }
+}

--- a/24th-App-Team-1-iOS/Domain/CommonDomain/Sources/Entities/ProfileOnboardingQuery.swift
+++ b/24th-App-Team-1-iOS/Domain/CommonDomain/Sources/Entities/ProfileOnboardingQuery.swift
@@ -1,0 +1,18 @@
+//
+//  ProfileOnboardingQuery.swift
+//  CommonDomain
+//
+//  Created by 김도현 on 2/25/25.
+//
+
+import Foundation
+
+
+
+public struct ProfileOnboardingQuery {
+    public let publishNotificationType: String
+    
+    public init(publishNotificationType: String) {
+        self.publishNotificationType = publishNotificationType
+    }
+}

--- a/24th-App-Team-1-iOS/Domain/CommonDomain/Sources/Repositories/CommonRepositoryProtocol.swift
+++ b/24th-App-Team-1-iOS/Domain/CommonDomain/Sources/Repositories/CommonRepositoryProtocol.swift
@@ -18,4 +18,5 @@ public protocol CommonRepositoryProtocol {
     func createProfilePresignedURL(query: CreateProfilePresignedURLQuery) -> Single<CreateProfilePresignedURLEntity?>
     func uploadUserProfileImage(_ image: Data, presigendURL: String) -> Single<Bool>
     func fetchAppVersionItem() async throws -> WSVersionEntity
+    func fetchProfileOnbardingItem(query: ProfileOnboardingQuery) async throws -> ProfileOnboardingEntity
 }

--- a/24th-App-Team-1-iOS/Domain/SplashDomain/Sources/UseCases/FetchProfileOnboardingInfoUseCase.swift
+++ b/24th-App-Team-1-iOS/Domain/SplashDomain/Sources/UseCases/FetchProfileOnboardingInfoUseCase.swift
@@ -1,0 +1,31 @@
+//
+//  FetchProfileOnboardingInfoUseCase.swift
+//  SplashDomain
+//
+//  Created by 김도현 on 2/25/25.
+//
+
+import Foundation
+
+import CommonDomain
+
+public protocol FetchProfileOnboardingInfoUseCaseProtocol {
+    func execute(query: ProfileOnboardingQuery) async throws -> ProfileOnboardingEntity
+}
+
+
+public final class FetchProfileOnboardingInfoUseCase: FetchProfileOnboardingInfoUseCaseProtocol {
+            
+    private let commonRepository: CommonRepositoryProtocol
+    
+    public init(commonRepository: CommonRepositoryProtocol) {
+        self.commonRepository = commonRepository
+    }
+    
+    
+    public func execute(query: CommonDomain.ProfileOnboardingQuery) async throws -> CommonDomain.ProfileOnboardingEntity {
+        return try await commonRepository.fetchProfileOnbardingItem(query: query)
+    }
+    
+    
+}

--- a/24th-App-Team-1-iOS/Feature/LoginFeature/Sources/Presentation/Reactors/SignInViewReactor.swift
+++ b/24th-App-Team-1-iOS/Feature/LoginFeature/Sources/Presentation/Reactors/SignInViewReactor.swift
@@ -101,7 +101,7 @@ public final class SignInViewReactor: Reactor {
             KeychainManager.shared.set(value: userInfo.refreshToken,
                                        type: .refreshToken)
             
-            NotificationCenter.default.post(name: .showVoteMainViewController, object: nil)
+            NotificationCenter.default.post(name: .dismissProfileOnboardingView, object: nil)
         }
         return newState
     }

--- a/24th-App-Team-1-iOS/Feature/SplashFeature/Sources/Presentation/View/ProfileOnboardingView.swift
+++ b/24th-App-Team-1-iOS/Feature/SplashFeature/Sources/Presentation/View/ProfileOnboardingView.swift
@@ -24,7 +24,7 @@ public struct ProfileOnboardingView: View {
                 .frame(maxWidth: .infinity, minHeight: 60)
                 .foregroundColor(DesignSystemAsset.Colors.gray900.swiftUIColor)
                 .padding(.top, 44)
-            
+
             ScrollView {
                 VStack {
                     VStack(alignment: .leading) {
@@ -33,7 +33,7 @@ public struct ProfileOnboardingView: View {
                             .lineSpacing(10)
                             .font(DesignSystemFontFamily.Pretendard.bold.swiftUIFont(size: 20))
                             .multilineTextAlignment(.leading)
-                        
+
                         Text(viewModel.state.subTitleComponentText)
                             .lineLimit(1)
                             .font(DesignSystemFontFamily.Pretendard.medium.swiftUIFont(size: 14))
@@ -44,15 +44,22 @@ public struct ProfileOnboardingView: View {
                     .padding(.horizontal, 20)
                     .padding(.bottom, 20)
                     
-                    ZStack(alignment: .center) {
-                        VStack {
-                            AsyncImage(url: viewModel.state.imageComponent?.imageURL)
-                                .frame(maxWidth: CGFloat(viewModel.state.imageComponent?.imageWidth ?? 0), maxHeight: CGFloat(viewModel.state.imageComponent?.imageHeight ?? 0))
-                                .padding(.horizontal, 70)
-                            .frame(maxWidth: 336, maxHeight: 120)
+                    ZStack(alignment: .bottom) {
+                        AsyncImage(url: viewModel.state.imageComponent?.imageURL) { phase in
+                            switch phase {
+                            case .empty:
+                                ProgressView()
+                            case .success(let image):
+                                image
+                                    .resizable()
+                                    .scaledToFill()
+                                    .frame(maxWidth: 270, maxHeight: 320)
+                            case .failure(_):
+                                ProgressView()
+                            @unknown default:
+                                EmptyView()
+                            }
                         }
-                        .frame(maxWidth: 336, maxHeight: 120)
-                        
                         LinearGradient(
                             gradient: Gradient(stops: [
                                 .init(color: Color(UIColor(red: 27/255, green: 28/255, blue: 30/255, alpha: 0)), location: 0),
@@ -62,18 +69,18 @@ public struct ProfileOnboardingView: View {
                             startPoint: .top,
                             endPoint: .bottom
                         )
+                        .frame(width: 270, height: 116)
+                        .clipped()
                     }
-                    .frame(maxWidth: .infinity, maxHeight: 446)
-                    .padding(.top, 16)
-                    
-                    
+                    .frame(width: 270, height: 320)
+
                     VStack(alignment: .leading) {
                         ZStack {
                             RoundedRectangle(cornerRadius: 20)
                                 .stroke(DesignSystemAsset.Colors.primary300.swiftUIColor, lineWidth: 1)
                                 .background(DesignSystemAsset.Colors.gray600.swiftUIColor)
                                 .clipped()
-                            
+
                             Text(viewModel.state.chipComponentText)
                                 .font(DesignSystemFontFamily.Pretendard.semiBold.swiftUIFont(size: 15))
                                 .foregroundStyle(DesignSystemAsset.Colors.white.swiftUIColor)
@@ -85,7 +92,6 @@ public struct ProfileOnboardingView: View {
                     .padding(.horizontal, 20)
                     .padding(.bottom, 20)
                     
-                    
                     Text(viewModel.state.descriptionComponentText)
                         .font(DesignSystemFontFamily.Pretendard.medium.swiftUIFont(size: 14))
                         .foregroundStyle(DesignSystemAsset.Colors.gray200.swiftUIColor)
@@ -93,13 +99,23 @@ public struct ProfileOnboardingView: View {
                         .frame(maxWidth: .infinity, maxHeight: 42, alignment: .leading)
                         .padding(.leading, 20)
                         .padding(.bottom, 45)
-                    
-                    ZStack {
-                        AsyncImage(url: viewModel.state.descriptionImageComponent?.imageURL)
-                            .frame(maxWidth: CGFloat(viewModel.state.descriptionImageComponent?.imageWidth ?? 0),
-                                   maxHeight: CGFloat(viewModel.state.descriptionImageComponent?.imageHeight ?? 0))
-                        Spacer()
-                        
+
+                    ZStack(alignment: .bottom) {
+                        AsyncImage(url: viewModel.state.descriptionImageComponent?.imageURL) { phase in
+                            switch phase {
+                            case .empty:
+                                ProgressView()
+                            case .success(let image):
+                                image
+                                    .resizable()
+                                    .scaledToFill()
+                                    .frame(maxWidth: 270, maxHeight: 320)
+                            case .failure(_):
+                                ProgressView()
+                            @unknown default:
+                                EmptyView()
+                            }
+                        }
                         LinearGradient(
                             gradient: Gradient(stops: [
                                 .init(color: Color(UIColor(red: 27/255, green: 28/255, blue: 30/255, alpha: 0)), location: 0),
@@ -109,12 +125,15 @@ public struct ProfileOnboardingView: View {
                             startPoint: .top,
                             endPoint: .bottom
                         )
-                        .frame(maxWidth: 336, maxHeight: 120)
-                        
+                        .frame(width: 270, height: 116)
+                        .clipped()
                     }
+                    .frame(width: 270, height: 320)
+
                 }
                 .padding(.top, 16)
             }
+            .padding(.bottom, 40)
 
             HStack {
                 Button {
@@ -127,9 +146,9 @@ public struct ProfileOnboardingView: View {
                         .background(DesignSystemAsset.Colors.gray500.swiftUIColor)
                         .cornerRadius(10)
                 }
-                
+
                 Spacer()
-                
+
                 Button {
                     Task {
                         await viewModel.dispatcher(action: .didTappedUpdateProfile)

--- a/24th-App-Team-1-iOS/Feature/SplashFeature/Sources/Presentation/View/ProfileOnboardingView.swift
+++ b/24th-App-Team-1-iOS/Feature/SplashFeature/Sources/Presentation/View/ProfileOnboardingView.swift
@@ -1,0 +1,217 @@
+//
+//  ProfileOnboardingView.swift
+//  SplashFeature
+//
+//  Created by 김도현 on 2/25/25.
+//
+
+import SwiftUI
+
+import DesignSystem
+
+
+public struct ProfileOnboardingView: View {
+    @ObservedObject private var viewModel: ProfileOnboardingViewModel
+    @Environment(\.dismiss) var dismiss
+    
+    public init(viewModel: ProfileOnboardingViewModel) {
+        self.viewModel = viewModel
+    }
+    
+    public var body: some View {
+        VStack(spacing: 0) {
+            WSNavigationBarView(navigationProperty: .leftWithCenterItem(DesignSystemAsset.Images.arrow.image, "새로운 기능"), text: viewModel.state.topComponentText)
+                .frame(maxWidth: .infinity, minHeight: 60)
+                .foregroundColor(DesignSystemAsset.Colors.gray900.swiftUIColor)
+                .padding(.top, 44)
+            
+            ScrollView {
+                VStack {
+                    VStack(alignment: .leading) {
+                        Text(viewModel.state.titleComponentText)
+                            .lineLimit(nil)
+                            .lineSpacing(10)
+                            .font(DesignSystemFontFamily.Pretendard.bold.swiftUIFont(size: 20))
+                            .multilineTextAlignment(.leading)
+                        
+                        Text(viewModel.state.subTitleComponentText)
+                            .lineLimit(1)
+                            .font(DesignSystemFontFamily.Pretendard.medium.swiftUIFont(size: 14))
+                            .foregroundStyle(DesignSystemAsset.Colors.gray600.swiftUIColor)
+                            .multilineTextAlignment(.leading)
+                            .frame(maxWidth: .infinity, maxHeight: 21, alignment: .leading)
+                    }
+                    .padding(.horizontal, 20)
+                    .padding(.bottom, 20)
+                    
+                    ZStack(alignment: .center) {
+                        VStack {
+                            AsyncImage(url: viewModel.state.imageComponent?.imageURL)
+                                .frame(maxWidth: CGFloat(viewModel.state.imageComponent?.imageWidth ?? 0), maxHeight: CGFloat(viewModel.state.imageComponent?.imageHeight ?? 0))
+                                .padding(.horizontal, 70)
+                            .frame(maxWidth: 336, maxHeight: 120)
+                        }
+                        .frame(maxWidth: 336, maxHeight: 120)
+                        
+                        LinearGradient(
+                            gradient: Gradient(stops: [
+                                .init(color: Color(UIColor(red: 27/255, green: 28/255, blue: 30/255, alpha: 0)), location: 0),
+                                .init(color: Color(UIColor(red: 27/255, green: 28/255, blue: 30/255, alpha: 1)), location: 0.63),
+                                .init(color: Color(UIColor(red: 27/255, green: 28/255, blue: 30/255, alpha: 1)), location: 1)
+                            ]),
+                            startPoint: .top,
+                            endPoint: .bottom
+                        )
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: 446)
+                    .padding(.top, 16)
+                    
+                    
+                    VStack(alignment: .leading) {
+                        ZStack {
+                            RoundedRectangle(cornerRadius: 20)
+                                .stroke(DesignSystemAsset.Colors.primary300.swiftUIColor, lineWidth: 1)
+                                .background(DesignSystemAsset.Colors.gray600.swiftUIColor)
+                                .clipped()
+                            
+                            Text(viewModel.state.chipComponentText)
+                                .font(DesignSystemFontFamily.Pretendard.semiBold.swiftUIFont(size: 15))
+                                .foregroundStyle(DesignSystemAsset.Colors.white.swiftUIColor)
+                        }
+                        .frame(width: 113, height: 33)
+                        .clipShape(RoundedRectangle(cornerRadius: 20))
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: 33, alignment: .leading)
+                    .padding(.horizontal, 20)
+                    .padding(.bottom, 20)
+                    
+                    
+                    Text(viewModel.state.descriptionComponentText)
+                        .font(DesignSystemFontFamily.Pretendard.medium.swiftUIFont(size: 14))
+                        .foregroundStyle(DesignSystemAsset.Colors.gray200.swiftUIColor)
+                        .lineLimit(nil)
+                        .frame(maxWidth: .infinity, maxHeight: 42, alignment: .leading)
+                        .padding(.leading, 20)
+                        .padding(.bottom, 45)
+                    
+                    ZStack {
+                        AsyncImage(url: viewModel.state.descriptionImageComponent?.imageURL)
+                            .frame(maxWidth: CGFloat(viewModel.state.descriptionImageComponent?.imageWidth ?? 0),
+                                   maxHeight: CGFloat(viewModel.state.descriptionImageComponent?.imageHeight ?? 0))
+                        Spacer()
+                        
+                        LinearGradient(
+                            gradient: Gradient(stops: [
+                                .init(color: Color(UIColor(red: 27/255, green: 28/255, blue: 30/255, alpha: 0)), location: 0),
+                                .init(color: Color(UIColor(red: 27/255, green: 28/255, blue: 30/255, alpha: 1)), location: 0.63),
+                                .init(color: Color(UIColor(red: 27/255, green: 28/255, blue: 30/255, alpha: 1)), location: 1)
+                            ]),
+                            startPoint: .top,
+                            endPoint: .bottom
+                        )
+                        .frame(maxWidth: 336, maxHeight: 120)
+                        
+                    }
+                }
+                .padding(.top, 16)
+            }
+
+            HStack {
+                Button {
+                    dismiss()
+                } label: {
+                    Text(viewModel.state.leftButtonComponentText)
+                        .font(DesignSystemFontFamily.Pretendard.semiBold.swiftUIFont(size: 16))
+                        .foregroundStyle(DesignSystemAsset.Colors.gray100.swiftUIColor)
+                        .frame(width: 162, height: 52)
+                        .background(DesignSystemAsset.Colors.gray500.swiftUIColor)
+                        .cornerRadius(10)
+                }
+                
+                Spacer()
+                
+                Button {
+                    Task {
+                        await viewModel.dispatcher(action: .didTappedUpdateProfile)
+                    }
+                } label: {
+                    Text(viewModel.state.rightButtonComponentText)
+                        .font(DesignSystemFontFamily.Pretendard.semiBold.swiftUIFont(size: 16))
+                        .foregroundStyle(DesignSystemAsset.Colors.gray900.swiftUIColor)
+                        .frame(width: 162, height: 52)
+                        .background(DesignSystemAsset.Colors.primary300.swiftUIColor)
+                        .cornerRadius(10)
+                }
+            }
+            .frame(width: 324, height: 52)
+            .padding(.horizontal, 20)
+            .padding(.bottom, 34)
+        }
+        .background(DesignSystemAsset.Colors.gray900.swiftUIColor)
+        .edgesIgnoringSafeArea(.all)
+        .onAppear {
+            Task {
+                await viewModel.dispatcher(action: .viewDidLoad)
+            }
+        }
+    }
+    
+    
+    
+    
+}
+
+#Preview {
+    ProfileOnboardingView(viewModel: ProfileOnboardingViewModel())
+}
+
+
+
+
+
+
+public struct WSNavigationBarView: View {
+    @Environment(\.dismiss) var dismiss
+    @State private var navigationProperty: WSNavigationType
+    @State private var text: String
+    
+    public init(navigationProperty: WSNavigationType, text: String) {
+        self.navigationProperty = navigationProperty
+        self.text = text
+    }
+    
+    public var body: some View {
+        makeContentView()
+            .frame(maxWidth: .infinity, minHeight: 44)
+    }
+    
+    @ViewBuilder
+    private func makeContentView() -> some View {
+        ZStack {
+            HStack {
+                Button(action: {
+                    dismiss()
+                }) {
+                    Image(uiImage: navigationProperty.items.leftItem ?? UIImage())
+                        .padding(.leading, 20)
+                }
+                .padding(.leading, 20)
+                .frame(width: 24, height: 24)
+                
+                Spacer()
+                
+                Text(navigationProperty.items.centerItem ?? "" )
+                    .font(DesignSystemFontFamily.Pretendard.semiBold.swiftUIFont(size: 18))
+                    .foregroundColor(DesignSystemAsset.Colors.gray100.swiftUIColor)
+                    .padding(.trailing, 20)
+                    .frame(maxWidth: .infinity, maxHeight: 27)
+                
+                Spacer()
+            }
+            .frame(maxWidth: .infinity)
+        }
+        .frame(maxWidth: .infinity)
+        .background(DesignSystemAsset.Colors.gray900.swiftUIColor)
+        .foregroundColor(.white)
+    }
+}

--- a/24th-App-Team-1-iOS/Feature/SplashFeature/Sources/Presentation/ViewControllers/ProfileOnboardingHostingViewController.swift
+++ b/24th-App-Team-1-iOS/Feature/SplashFeature/Sources/Presentation/ViewControllers/ProfileOnboardingHostingViewController.swift
@@ -1,0 +1,15 @@
+//
+//  ProfileOnboardingHostingViewController.swift
+//  SplashFeature
+//
+//  Created by 김도현 on 2/27/25.
+//
+
+import SwiftUI
+
+
+final class ProfileOnboardingHostingViewController: UIHostingController<ProfileOnboardingView> {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+}

--- a/24th-App-Team-1-iOS/Feature/SplashFeature/Sources/Presentation/ViewControllers/ProfileOnboardingHostingViewController.swift
+++ b/24th-App-Team-1-iOS/Feature/SplashFeature/Sources/Presentation/ViewControllers/ProfileOnboardingHostingViewController.swift
@@ -8,8 +8,15 @@
 import SwiftUI
 
 
-final class ProfileOnboardingHostingViewController: UIHostingController<ProfileOnboardingView> {
-    override func viewDidLoad() {
+public final class ProfileOnboardingHostingViewController: UIHostingController<ProfileOnboardingView> {
+    
+    public override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.setNavigationBarHidden(true, animated: false)
+        NotificationCenter.default.post(name: .hideTabBar, object: nil)
+    }
+    
+    public override func viewDidLoad() {
         super.viewDidLoad()
     }
 }

--- a/24th-App-Team-1-iOS/Feature/SplashFeature/Sources/Presentation/ViewModel/ProfileOnboardingViewModel.swift
+++ b/24th-App-Team-1-iOS/Feature/SplashFeature/Sources/Presentation/ViewModel/ProfileOnboardingViewModel.swift
@@ -1,0 +1,193 @@
+//
+//  ProfileOnboardingViewModel.swift
+//  SplashFeature
+//
+//  Created by 김도현 on 2/25/25.
+//
+
+import Foundation
+
+import Util
+import CommonDomain
+import SplashDomain
+
+typealias ImageComponent = (imageURL:URL, imageWidth: Int, imageHeight: Int)
+
+public final class ProfileOnboardingViewModel: ObservableObject {
+    
+    
+    @Published var state: State = .init()
+    @Injected private var fetchProfileOnboardingUseCase: FetchProfileOnboardingInfoUseCaseProtocol
+    
+    struct State {
+        var componentEntity: ProfileOnboardingEntity?
+        var titleComponentText: String = ""
+        var topComponentText: String = ""
+        var subTitleComponentText: String = ""
+        var errorDescription: String = ""
+        var imageComponent: ImageComponent?
+        var descriptionComponentText: String = ""
+        var chipComponentText: String = ""
+        var descriptionImageComponent: ImageComponent?
+        var leftButtonComponentText: String = ""
+        var rightButtonComponentText: String = ""
+        
+    }
+    
+    public enum Action {
+        case viewDidLoad
+        case didTappedUpdateProfile
+    }
+    
+    
+    public enum Mutation {
+        case setComponentEntity(ProfileOnboardingEntity)
+        case setComponentError(String)
+        case none
+    }
+    
+    public init() { }
+    
+    public func dispatcher(action: Action) async {
+        let mutation = await mutate(action)
+        let newState = await reduce(state: state, mutation: mutation)
+        await MainActor.run {
+            state = newState
+        }
+    }
+    
+    private func mutate(_ action: Action) async -> Mutation {
+        switch action {
+        case .viewDidLoad:
+            let query = ProfileOnboardingQuery(publishNotificationType: "PROFILE_UPDATE")
+            do {
+                let response = try await fetchProfileOnboardingUseCase.execute(query: query)
+                return .setComponentEntity(response)
+            } catch {
+                return .setComponentError(error.localizedDescription)
+            }
+        case .didTappedUpdateProfile:
+            guard let currentState = state.componentEntity else { return .none }
+            await handleProfileEditDeepLink(entity: currentState)
+            return .none
+        }
+    }
+    
+    private func reduce(state: State, mutation: Mutation) async -> State {
+        var newState = state
+        switch mutation {
+        case let .setComponentEntity(entity):
+            newState.componentEntity = entity
+            newState.titleComponentText = transformTitleComponentText(entity: entity)
+            newState.topComponentText = transformTopComponentText(entity: entity)
+            newState.subTitleComponentText = transformSubTitleComponentText(entity: entity)
+            newState.imageComponent = transformImageComponent(entity: entity)
+            newState.chipComponentText = transformChipComponent(entity: entity)
+            newState.descriptionComponentText = transformDescriptionComponent(entity: entity)
+            newState.descriptionImageComponent = transformDescriptionImageComponent(entity: entity)
+            newState.leftButtonComponentText = transformLeftButtonComponent(entity: entity)
+            newState.rightButtonComponentText = transformRightButtonComponent(entity: entity)
+        case let .setComponentError(errorDescription):
+            newState.errorDescription = errorDescription
+        case .none:
+            break
+            
+        }
+        
+        return newState
+    }
+    
+    
+}
+
+
+extension ProfileOnboardingViewModel {
+    private func transformTitleComponentText(entity: ProfileOnboardingEntity) -> String {
+  
+        guard let titleComponentType = entity.components.first(where: { $0.componentType == "titleComponent" }),
+              let titleText = titleComponentType.titleText else { return "" }
+        return titleText.replacingOccurrences(of: "사진으로 프", with: "사진으로\n프")
+    }
+    
+    private func transformTopComponentText(entity: ProfileOnboardingEntity) -> String {
+        guard let topComponentType = entity.components.first(where: { $0.componentType == "topBarComponent" }),
+              let topText = topComponentType.titleText else { return "" }
+        print("내비게이션 타이틀 확인 합니다 : \(topText)")
+        return topText
+    }
+    
+    private func transformSubTitleComponentText(entity: ProfileOnboardingEntity) -> String {
+        guard let subtitleComponentType = entity.components.first(where: { $0.componentType == "subTitleComponent"}),
+              let subTitletext = subtitleComponentType.titleText else { return "" }
+        return subTitletext
+    }
+    
+    private func transformImageComponent(entity: ProfileOnboardingEntity) -> ImageComponent? {
+        guard let imageComponentType = entity.components.first(where: { $0.componentType == "imageComponent"}),
+              let imageAbsoluteString = imageComponentType.imageURL,
+              let imageURL = URL(string: imageAbsoluteString),
+              let imageWidth = imageComponentType.width,
+              let imageHeight = imageComponentType.height else { return nil }
+        
+        return (imageURL, imageWidth, imageHeight)
+    }
+    
+    private func transformChipComponent(entity: ProfileOnboardingEntity) -> String {
+        guard let chipComponent = entity.components.first(where: { $0.componentType == "chipComponent"}),
+              let chipText = chipComponent.titleText else { return "" }
+        return chipText
+    }
+    
+    
+    private func transformDescriptionComponent(entity: ProfileOnboardingEntity) -> String {
+        guard let descriptionComponentType = entity.components.first(where: { $0.componentType == "descriptionComponent"}),
+              let descriptionText = descriptionComponentType.titleText else { return "" }
+        return descriptionText.replacingOccurrences(of: "프로필은 반", with: "프로필은\n반")
+    }
+    
+    private func transformDescriptionImageComponent(entity: ProfileOnboardingEntity) -> ImageComponent? {
+        guard let descriptionImageComponentType = entity.components.first(where: { $0.componentType == "descriptionImageComponent"}),
+              let descriptionImageAbsoluteString = descriptionImageComponentType.imageURL,
+              let descriptionImageURL = URL(string: descriptionImageAbsoluteString),
+              let descriptionImageWidth = descriptionImageComponentType.width,
+              let descriptionImageHeight = descriptionImageComponentType.height else { return nil }
+        
+        return (descriptionImageURL, descriptionImageWidth, descriptionImageHeight)
+    }
+    
+    private func transformLeftButtonComponent(entity: ProfileOnboardingEntity) -> String {
+        guard let buttonComponentType = entity.components.first(where: { $0.componentType == "buttonListComponent"}),
+              let leftButton = buttonComponentType.buttonComponentList?.first else { return "" }
+        
+        return leftButton.text
+    }
+    
+    private func transformRightButtonComponent(entity: ProfileOnboardingEntity) -> String {
+        guard let buttonComponentType = entity.components.first(where: { $0.componentType == "buttonListComponent"}),
+              let rightButton = buttonComponentType.buttonComponentList?.last else { return "" }
+        
+        return rightButton.text
+    }
+    
+    @MainActor
+    private func handleProfileEditDeepLink(entity: ProfileOnboardingEntity) async  {
+        
+        
+        guard let buttonComponentType =  entity.components.first(where: { $0.componentType == "buttonListComponent"}),
+              let rightButton = buttonComponentType.buttonComponentList?.last,
+              let deepLink = rightButton.onClickAction.deepLink,
+              let url = URL(string: deepLink),
+              let urlScheme = url.scheme,
+              let urlHost = url.host else { return }
+        
+        let urlPath = url.path
+        
+        print("딥링크 URL을 확인합니다 : \(url) , \(urlScheme) , \(urlHost) , \(urlPath)")
+        
+        if urlScheme == "wespot" && urlHost == "all" && urlPath == "/profile-edit" {
+            NotificationCenter.default.post(name: .showProfileSettingViewController, object: nil)
+        }
+
+    }
+    
+}

--- a/24th-App-Team-1-iOS/Service/CommonService/Sources/DataMapping/ProfileOnbardingInfoRequestDTO.swift
+++ b/24th-App-Team-1-iOS/Service/CommonService/Sources/DataMapping/ProfileOnbardingInfoRequestDTO.swift
@@ -1,0 +1,17 @@
+//
+//  ProfileOnbardingInfoRequestDTO.swift
+//  CommonService
+//
+//  Created by 김도현 on 2/25/25.
+//
+
+import Foundation
+
+public struct ProfileOnbardingInfoRequestDTO: Encodable {
+    public let publishNotificationType: String
+    
+    
+    init(publishNotificationType: String) {
+        self.publishNotificationType = publishNotificationType
+    }
+}

--- a/24th-App-Team-1-iOS/Service/CommonService/Sources/DataMapping/ProfileOnboardingResponseDTO.swift
+++ b/24th-App-Team-1-iOS/Service/CommonService/Sources/DataMapping/ProfileOnboardingResponseDTO.swift
@@ -1,0 +1,88 @@
+//
+//  ProfileOnboardingResponseDTO.swift
+//  CommonService
+//
+//  Created by 김도현 on 2/25/25.
+//
+
+import Foundation
+
+import CommonDomain
+
+public struct ProfileOnboardingResponseDTO: Decodable {
+    public let id: Int
+    public let name: String
+    public let components: [ProfileComponentsResponseDTO]
+    
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case components = "data"
+    }
+}
+
+public extension ProfileOnboardingResponseDTO {
+    struct ProfileComponentsResponseDTO: Decodable {
+        public let componentType: String
+        public let titleText: String?
+        public let imageURL: String?
+        public let width: Int?
+        public let height: Int?
+        public let buttonComponentList: [ProfileButtonComponentResponseDTO]?
+        
+        private enum CodingKeys: String, CodingKey {
+            case componentType = "type"
+            case titleText = "text"
+            case imageURL = "url"
+            case width
+            case height
+            case buttonComponentList = "buttonList"
+        }
+    }
+}
+
+
+public extension ProfileOnboardingResponseDTO.ProfileComponentsResponseDTO {
+    struct ProfileButtonComponentResponseDTO: Decodable {
+        public let text: String
+        public let textColor: String
+        public let pressColor: String
+        public let buttonColor: String
+        public let onClickAction: ProfileButtonClickActionResponseDTO
+    }
+}
+
+public extension ProfileOnboardingResponseDTO.ProfileComponentsResponseDTO.ProfileButtonComponentResponseDTO {
+    struct ProfileButtonClickActionResponseDTO: Decodable {
+        public let type: String?
+        public let deepLink: String?
+    }
+}
+
+
+
+public extension ProfileOnboardingResponseDTO {
+    func toDomain() -> ProfileOnboardingEntity {
+        return .init(id: id, name: name, components: components.map { $0.toDomain()} )
+    }
+}
+
+public extension ProfileOnboardingResponseDTO.ProfileComponentsResponseDTO {
+    func toDomain() -> ProfileOnboardingComponentsEntity {
+        return .init(componentType: componentType, titleText: titleText, imageURL: imageURL, width: width, height: height, buttonComponentList: buttonComponentList?.compactMap { $0.toDomain()})
+    }
+}
+
+
+
+public extension ProfileOnboardingResponseDTO.ProfileComponentsResponseDTO.ProfileButtonComponentResponseDTO {
+    func toDomain() -> ProfileButtonComponentListEntity {
+        return .init(text: text, textColor: textColor, pressColor: pressColor, buttonColor: buttonColor, onClickAction: onClickAction.toDomain())
+    }
+}
+
+public extension ProfileOnboardingResponseDTO.ProfileComponentsResponseDTO.ProfileButtonComponentResponseDTO.ProfileButtonClickActionResponseDTO {
+    func toDomain() -> ProfileButtonClickActionEntity {
+        return .init(type: type, deepLink: deepLink)
+    }
+}

--- a/24th-App-Team-1-iOS/Service/CommonService/Sources/Repository/CommonRepository.swift
+++ b/24th-App-Team-1-iOS/Service/CommonService/Sources/Repository/CommonRepository.swift
@@ -21,6 +21,7 @@ public final class CommonRepository: CommonRepositoryProtocol {
     
     
     private let networkService: WSNetworkServiceProtocol = WSNetworkService()
+    private let networkAsyncService: WSNetworkAsyncServiceProtocol = WSNetworkAsyncService()
     private let dataSources: RemoteConfig = RemoteConfig.remoteConfig()
     
     public init() { }
@@ -127,5 +128,12 @@ public final class CommonRepository: CommonRepositoryProtocol {
         } else {
             throw WSRemoteConfigError.invalidFirebaseConfigure
         }
+    }
+    
+    public func fetchProfileOnbardingItem(query: ProfileOnboardingQuery) async throws -> ProfileOnboardingEntity {
+        let query = ProfileOnbardingInfoRequestDTO(publishNotificationType: query.publishNotificationType)
+        let endPoint = CommonEndPoint.fetchProfileOnboarding(query)
+        let responseDTO: ProfileOnboardingResponseDTO = try await networkAsyncService.request(endPoint: endPoint)
+        return responseDTO.toDomain()
     }
 }

--- a/24th-App-Team-1-iOS/Shared/DesignSystem/Sources/Components/NavigationBar/WSNavigationTypeProperty.swift
+++ b/24th-App-Team-1-iOS/Shared/DesignSystem/Sources/Components/NavigationBar/WSNavigationTypeProperty.swift
@@ -10,15 +10,15 @@ import UIKit
 /// WSNavigationTypeProperty로 각 **WSNavigationType**에 맞게 UI를 구성할 수 있습니다.
 public struct WSNavigationTypeProperty: Equatable {
     /// leftBarButtonItem UI를 구성하기 위한 프로퍼티 입니다.
-    var leftItem: UIImage?
+    public var leftItem: UIImage?
     /// centernItem UI를 구성하기 위한 프러퍼티 입니다.
-    var centerItem: String?
+    public var centerItem: String?
     /// rightBarButtonItem Image UI를 구성하기 위한 프로퍼티 입니다.
-    var rightImageItem: UIImage?
+    public var rightImageItem: UIImage?
     /// rightBarButtonItem  Text UI를 구성하기 위한 프로퍼티 입니다.
-    var rightTextItem: String?
+    public var rightTextItem: String?
     /// rightBarButtonItem Text Color를 구성하기 위한 프로퍼티 입니다.
-    var rightTextItemColor: UIColor?
+    public var rightTextItemColor: UIColor?
 }
 
 
@@ -33,7 +33,7 @@ public enum WSNavigationType: Equatable {
     case leftWithRightItem(UIImage, String, UIImage)
     case all(UIImage, String?, String?, UIColor)
     
-    var items: WSNavigationTypeProperty {
+    public var items: WSNavigationTypeProperty {
         switch self {
         case .default:
             return .init(


### PR DESCRIPTION
## 작업 내용

- [x] 프로필 온보딩 UI (ProfileOnboardingView) Layout 추가하였습니다.
- [x] `WSNetworkAsyncService ` 네트워크 모듈을 추가하였습니다.
- [x] `ProfileOnboardingViewModel` 내부 Reactor와 최대한 비슷하게 구현하였습니다.


## 화면 
![Simulator Screenshot - iPhone 16 - 2025-03-01 at 17 57 07](https://github.com/user-attachments/assets/72be3126-1f9c-4c47-b3df-052af9d41f93)





<br/><br/><br/>
close: #31 
