### PR TITLE
[Fix] 커뮤니티 게시글 중복 작성 버그 수정

### DIFF
--- a/24th-App-Team-1-iOS/Feature/CommunityFeature/Sources/Presentation/Feature/PostWriteFeature.swift
+++ b/24th-App-Team-1-iOS/Feature/CommunityFeature/Sources/Presentation/Feature/PostWriteFeature.swift
@@ -29,6 +29,7 @@ public struct PostWriteFeature {
         var isShowingCategorySheet = false
         var selectedCategory: CategoryChipsEntity? = nil
         var didUploadSuccess = false
+        var isSubmitting = false
         var isMain: Bool
         var postTitle: String = ""
         var postDescription: String = ""
@@ -51,6 +52,7 @@ public struct PostWriteFeature {
             && !postDescription.isEmpty
             && !descriptionTooLong
             && !titleTooLong
+            && !isSubmitting
         }
         
         public init(editingPost: PostItem? = nil, selectedCategory: CategoryChipsEntity? = nil, isEditing: Bool = false, isMain: Bool = true) {
@@ -220,7 +222,9 @@ public struct PostWriteFeature {
 
                 
             case .view(.submitButtonTapped):
+                guard !state.isSubmitting else { return .none }
                 guard let category = state.selectedCategory else { return .none }
+                state.isSubmitting = true
                 let categoryId = category.id
                 let title = state.postTitle
                 let description = state.postDescription
@@ -350,6 +354,7 @@ public struct PostWriteFeature {
                 return .none
             case let .internal(.postUploadResponse(success)):
                 print("게시글 업로드 성공 여부 값 입니다 : \(success)")
+                state.isSubmitting = false
                 if success {
                     state.didUploadSuccess = true
                 }

--- a/24th-App-Team-1-iOS/Feature/CommunityFeature/Sources/Presentation/Feature/PostWriteFeature.swift
+++ b/24th-App-Team-1-iOS/Feature/CommunityFeature/Sources/Presentation/Feature/PostWriteFeature.swift
@@ -224,13 +224,13 @@ public struct PostWriteFeature {
             case .view(.submitButtonTapped):
                 guard !state.isSubmitting else { return .none }
                 guard let category = state.selectedCategory else { return .none }
-                state.isSubmitting = true
                 let categoryId = category.id
                 let title = state.postTitle
                 let description = state.postDescription
 
                 if state.isEditing {
                     guard let editingPost = state.editingPost else { return .none }
+                    state.isSubmitting = true
                     let postId = editingPost.id
 
                     let newPresignedList = state.preSignedURLEntity
@@ -280,6 +280,7 @@ public struct PostWriteFeature {
                     }
 
                 } else {
+                    state.isSubmitting = true
                     let presignedList = state.preSignedURLEntity
                     let imageDataList = state.photoImageData
 

--- a/24th-App-Team-1-iOS/Feature/CommunityFeature/Sources/Presentation/View/PostWriteView.swift
+++ b/24th-App-Team-1-iOS/Feature/CommunityFeature/Sources/Presentation/View/PostWriteView.swift
@@ -286,7 +286,6 @@ struct PostWriteView: View {
         }) {
             if viewStore.isSubmitting {
                 ProgressView()
-                    .progressViewStyle(CircularProgressViewStyle(tint: DesignSystemAsset.Colors.gray900.swiftUIColor))
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
                 Text("게시하기")

--- a/24th-App-Team-1-iOS/Feature/CommunityFeature/Sources/Presentation/View/PostWriteView.swift
+++ b/24th-App-Team-1-iOS/Feature/CommunityFeature/Sources/Presentation/View/PostWriteView.swift
@@ -284,10 +284,16 @@ struct PostWriteView: View {
         Button(action: {
             viewStore.send(.view(.submitButtonTapped))
         }) {
-            Text("게시하기")
-                .font(DesignSystemFontFamily.Pretendard.bold.swiftUIFont(size: 16))
-                .foregroundColor(viewStore.canSubmit ? DesignSystemAsset.Colors.gray900.swiftUIColor : DesignSystemAsset.Colors.gray300.swiftUIColor)
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            if viewStore.isSubmitting {
+                ProgressView()
+                    .progressViewStyle(CircularProgressViewStyle(tint: DesignSystemAsset.Colors.gray900.swiftUIColor))
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                Text("게시하기")
+                    .font(DesignSystemFontFamily.Pretendard.bold.swiftUIFont(size: 16))
+                    .foregroundColor(viewStore.canSubmit ? DesignSystemAsset.Colors.gray900.swiftUIColor : DesignSystemAsset.Colors.gray300.swiftUIColor)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
         }
         .frame(height: 52)
         .background(viewStore.canSubmit ? DesignSystemAsset.Colors.primary300.swiftUIColor : DesignSystemAsset.Colors.gray500.swiftUIColor)


### PR DESCRIPTION
## 작업 내용

- [x] `PostWriteFeature`에 `isSubmitting` 상태 추가하여 게시글 작성 API 중복 호출 방지
- [x] `canSubmit` 조건에 `!isSubmitting` 추가하여 요청 중 버튼 자동 비활성화
- [x] `submitButtonTapped` 진입 시 `guard`로 중복 요청 차단 및 `isSubmitting = true` 설정
- [x] API 응답(`postUploadResponse`) 수신 시 `isSubmitting = false` 복구
- [x] `PostWriteView`의 게시하기 버튼에 로딩 인디케이터(`ProgressView`) 표시

## 화면 (Optional)

| Before | After |
|---|---|
| 버튼 빠르게 연속 탭 시 게시글 2개 생성 | 첫 탭 이후 버튼 비활성화 + 로딩 표시, 중복 생성 방지 |

<br/><br/><br/>
## 고민점 및 해결 방법 (Optional)

- `submitButtonTapped` 액션에 디바운스/취소 ID 대신 `isSubmitting` 플래그 방식을 선택
  - TCA `.cancellable(id:)`는 진행 중인 요청을 취소하는 용도이므로, 중복 방지 목적에는 상태 플래그가 더 명확
  - `canSubmit` computed property에 조건을 추가하여 View의 `.disabled` 바인딩과 자연스럽게 연동

<br/><br/><br/>
## 논의 해봤으면 좋으점 (Optional)



<br/><br/><br/>
## 레퍼런스 (Optional)



<br/><br/><br/>